### PR TITLE
Explain how to reach token-less state

### DIFF
--- a/credentials-quickstart/app/src/main/java/com/google/example/credentialsbasic/MainActivity.java
+++ b/credentials-quickstart/app/src/main/java/com/google/example/credentialsbasic/MainActivity.java
@@ -387,6 +387,8 @@ public class MainActivity extends AppCompatActivity implements
                     .putExtra(MockServer.EXTRA_IDTOKEN, idToken.getIdToken());
             startService(intent);
         } else {
+            // This state is reached if non-Google accounts are added to Gmail:
+            // https://support.google.com/mail/answer/6078445
             Log.d(TAG, "Credential does not contain ID Tokens.");
         }
     }


### PR DESCRIPTION
Even if we "filter" by Google accounts, request id tokens, and exclude email-only accounts, we can still receive accounts without id tokens. Explain how to get into this state.